### PR TITLE
(model) simplify enum attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ p.attributes # => {:name => "Bob Jane", :age => 32}
 
 The `attribute` macro takes two parameters. The field name with type and an optional default value.
 
-#### `enum_attibutes`
+#### `enum_attributes`
 
 Allows type safe enum defined attributes.<br>
 Same signature as `attribute` with an extra optional parameter to specify the serialisation of the enum member to either String or Int32, default is Int32.

--- a/spec/model_spec.cr
+++ b/spec/model_spec.cr
@@ -48,7 +48,7 @@ class EnumAttributes < ActiveModel::Model
   end
 
   enum_attribute size : Size, column_type: Int32, custom_tag: "what what"
-  enum_attribute product : Product = Product::Fries
+  enum_attribute product : Product = Product::Fries, column_type: String
 end
 
 class Changes < BaseKlass
@@ -210,8 +210,11 @@ describe ActiveModel::Model do
     it "should serialize enum attributes to a concrete value" do
       model = EnumAttributes.new(size: EnumAttributes::Size::Medium)
 
-      model._size_int.should eq EnumAttributes::Size::Medium.value
-      model._product_int.should eq EnumAttributes::Product::Fries.to_i
+      json = JSON.parse(model.to_json)
+      yaml = YAML.parse(model.to_yaml)
+
+      yaml["size"].should eq EnumAttributes::Size::Medium.to_i
+      json["product"].should eq EnumAttributes::Product::Fries.to_s
     end
 
     it "tracks changes to enum attributes" do


### PR DESCRIPTION
Simplifies the implementation of `enum_attribute` by removing `_{{column_type}}_{{enum_name}}` serialised attributes and utilising a generated JSON/YAML conversion class.