### PR TITLE
allow #attribute to accept a formatting block

### DIFF
--- a/spec/model_spec.cr
+++ b/spec/model_spec.cr
@@ -22,6 +22,14 @@ class AttributeOptions < ActiveModel::Model
   attribute weird : String | Int32
 end
 
+class SetterBlock < BaseKlass
+  attribute that_is : String = "cool"
+  attribute tricky : String do |t|
+    self.that_is = "not ok"
+    t.try &.downcase
+  end
+end
+
 class Inheritance < BaseKlass
   attribute boolean : Bool = true
 
@@ -188,6 +196,15 @@ describe ActiveModel::Model do
         :integer    => 45,
         :no_default => nil,
       })
+    end
+
+    it "should allow overriding of assignment" do
+      m = SetterBlock.new
+      m.that_is.should eq "cool"
+
+      m.tricky = "BUSINESS"
+      m.tricky.should eq "business"
+      m.that_is.should eq "not ok"
     end
   end
 

--- a/src/active-model/model.cr
+++ b/src/active-model/model.cr
@@ -281,7 +281,13 @@ abstract class ActiveModel::Model
           @{{name}}_changed = true
           @{{name}}_was = @{{name}}
         end
-        @{{name}} = value
+        {% if opts[:setter_block] %}
+          @{{name}} = ->({{ opts[:setter_block].args.first }} : {{opts[:klass]}} | Nil){
+            {{ opts[:setter_block].body }}
+          }.call value
+        {% else %}
+          @{{name}} = value
+        {% end %}
       end
     {% end %}
   end
@@ -440,7 +446,7 @@ abstract class ActiveModel::Model
     {% end %}
   end
 
-  macro attribute(name, converter = nil, mass_assignment = true, persistence = true, **tags)
+  macro attribute(name, converter = nil, mass_assignment = true, persistence = true, **tags, &block)
     @{{name.var}} : {{name.type}} | Nil
     # Attribute default value
     def {{name.var}}_default : {{name.type}} | Nil
@@ -461,6 +467,7 @@ abstract class ActiveModel::Model
         mass_assign:    mass_assignment,
         should_persist: persistence,
         tags:           tags,
+        setter_block:   block,
       }
     %}
     {%
@@ -470,6 +477,7 @@ abstract class ActiveModel::Model
         mass_assign:    mass_assignment,
         should_persist: persistence,
         tags:           tags,
+        setter_block:   block,
       }
     %}
     {% HAS_KEYS[0] = true %}


### PR DESCRIPTION
allow #attribute to accept a formatting block, called when an attribute is set

```crystal
class SetterBlock < ActiveModel::Model
  attribute that_is : String = "cool"
  attribute tricky : String do |t|
    self.that_is = "not ok"
    t.try &.downcase
  end
end

model = SetterBlock.new
model.that_is        # => "cool"
model.tricky = "BUSINESS"
model.tricky         # => "business"
model.that_is        # => "not ok"
```