### PR TITLE
refactor: model interfaces respect attribute type definitions

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: active-model
-version: 1.8.4
+version: 2.0.0
 
 dependencies:
   yaml_mapping:

--- a/shard.yml
+++ b/shard.yml
@@ -2,10 +2,13 @@ name: active-model
 version: 2.0.0
 
 dependencies:
-  yaml_mapping:
-    github: crystal-lang/yaml_mapping.cr
+  http-params-serializable:
+    github: vladfaust/http-params-serializable
+    version: ~> 0.3
   json_mapping:
     github: crystal-lang/json_mapping.cr
+  yaml_mapping:
+    github: crystal-lang/yaml_mapping.cr
 
 development_dependencies:
   ameba:

--- a/spec/callback_spec.cr
+++ b/spec/callback_spec.cr
@@ -131,7 +131,7 @@ describe ActiveModel::Callbacks do
     context "on a single model" do
       it "should successfully trigger the callback block" do
         hero = BlockHero.new(name: "Groucho")
-        hero.id.should be_nil
+        hero.@id.should be_nil
         hero.before_create
 
         hero.id.should be_a(Int32)
@@ -140,7 +140,7 @@ describe ActiveModel::Callbacks do
 
       it "should successfully trigger the callback" do
         hero = Hero.new(name: "Groucho")
-        hero.id.should be_nil
+        hero.@id.should be_nil
         hero.before_create
 
         hero.id.should be_a(Int32)
@@ -156,7 +156,7 @@ describe ActiveModel::Callbacks do
         heroes << BlockHero.new(name: "Thing")
         heroes << BlockHero.new(name: "Human Torch")
 
-        heroes.all? { |hero| hero.id.nil? }.should be_true
+        heroes.all? { |hero| hero.@id.nil? }.should be_true
         heroes.each(&.before_create)
         heroes.all? { |hero| hero.id.is_a?(Int32) }.should be_true
         heroes.all? { |hero| hero.id == hero.name.try(&.size) }.should be_true
@@ -165,29 +165,15 @@ describe ActiveModel::Callbacks do
       it "should successfully trigger the callback" do
         heroes = [] of Hero
 
-        hero1 = Hero.new(name: "Mr. Fantastic")
-        hero2 = Hero.new(name: "Invisible Woman")
-        hero3 = Hero.new(name: "Thing")
-        hero4 = Hero.new(name: "Human Torch")
+        heroes << Hero.new(name: "Mr. Fantastic")
+        heroes << Hero.new(name: "Invisible Woman")
+        heroes << Hero.new(name: "Thing")
+        heroes << Hero.new(name: "Human Torch")
 
-        heroes << hero1
-        heroes << hero2
-        heroes << hero3
-        heroes << hero4
+        heroes.all? { |hero| hero.@id.nil? }.should be_true
 
-        # NOTE:: this avoides a compiler bug
-        # Error: BUG: ClassName+ has no types
-        # https://forum.crystal-lang.org/t/detecting-class-types/1090/8
-        # heroes << Hero.new(name: "Mr. Fantastic")
-        # heroes << Hero.new(name: "Invisible Woman")
-        # heroes << Hero.new(name: "Thing")
-        # heroes << Hero.new(name: "Human Torch")
+        heroes.each &.before_create
 
-        heroes.all? { |hero| hero.id.nil? }.should be_true
-        hero1.before_create
-        hero2.before_create
-        hero3.before_create
-        hero4.before_create
         heroes.all? { |hero| hero.id.is_a?(Int32) }.should be_true
         heroes.all? { |hero| hero.id == hero.name.try(&.size) }.should be_true
       end

--- a/spec/model_spec.cr
+++ b/spec/model_spec.cr
@@ -164,13 +164,19 @@ describe ActiveModel::Model do
       bk = BaseKlass.new
       bk.string.should eq "hello"
       bk.integer.should eq 45
-      bk.no_default.should eq nil
+
+      expect_raises(NilAssertionError) do
+        bk.no_default
+      end
 
       i = Inheritance.new
       i.boolean.should eq true
       i.string.should eq "hello"
       i.integer.should eq 45
-      i.no_default.should eq nil
+
+      expect_raises(NilAssertionError) do
+        i.no_default
+      end
     end
 
     it "should allow attribute assignment" do

--- a/spec/model_spec.cr
+++ b/spec/model_spec.cr
@@ -141,7 +141,7 @@ describe ActiveModel::Model do
         :no_default => "jane",
       })
 
-      i = Inheritance.new({"string" => "bob", "no_default" => "jane", "boolean" => "True"})
+      i = Inheritance.new({"string" => "bob", "no_default" => "jane", "boolean" => "true"})
       i.attributes.should eq({
         :boolean    => true,
         :string     => "bob",

--- a/spec/model_spec.cr
+++ b/spec/model_spec.cr
@@ -301,8 +301,7 @@ describe ActiveModel::Model do
       bk = BaseKlass.new
       bk.clear_changes_information
 
-      params = HTTP::Params.new({"string" => ["what"]})
-      bk.assign_attributes(params)
+      bk.assign_attributes(string: "what")
       bk.changed_attributes.should eq({
         :string => "what",
       })
@@ -323,11 +322,8 @@ describe ActiveModel::Model do
     it "respects mass assignment preference option" do
       options = AttributeOptions.new
 
-      weird = "name"
-      params = HTTP::Params.new({"weird" => [weird], "bob" => ["bilbo"]})
-
-      options.assign_attributes(params)
-      options.weird.should eq weird
+      options.assign_attributes(weird: "weird", bob: "bilbo")
+      options.weird.should eq "weird"
       options.bob.should eq "Bobby"
     end
   end

--- a/spec/model_spec.cr
+++ b/spec/model_spec.cr
@@ -297,27 +297,12 @@ describe ActiveModel::Model do
   end
 
   describe "assign_attributes" do
-    it "assigns several attributes" do
-      bk = BaseKlass.new
-      bk.attributes.should eq({
-        :string     => "hello",
-        :integer    => 45,
-        :no_default => nil,
-      })
-
-      bk.assign_attributes(string: "what", integer: 42, no_default: "bath")
-      bk.attributes.should eq({
-        :string     => "what",
-        :integer    => 42,
-        :no_default => "bath",
-      })
-    end
-
     it "affects changes metadata" do
       bk = BaseKlass.new
       bk.clear_changes_information
 
-      bk.assign_attributes(string: "what")
+      params = HTTP::Params.new({"string" => ["what"]})
+      bk.assign_attributes(params)
       bk.changed_attributes.should eq({
         :string => "what",
       })
@@ -338,9 +323,11 @@ describe ActiveModel::Model do
     it "respects mass assignment preference option" do
       options = AttributeOptions.new
 
-      time = Time.unix(1459859781)
-      options.assign_attributes(time: time, bob: "Bilbo")
-      options.time.should eq time
+      weird = "name"
+      params = HTTP::Params.new({"weird" => [weird], "bob" => ["bilbo"]})
+
+      options.assign_attributes(params)
+      options.weird.should eq weird
       options.bob.should eq "Bobby"
     end
   end

--- a/spec/validation_spec.cr
+++ b/spec/validation_spec.cr
@@ -13,10 +13,10 @@ end
 class Person < ORM
   attribute name : String
   attribute age : Int32 = 32
-  attribute rating : Int32
-  attribute gender : String
+  attribute rating : Int32?
+  attribute gender : String?
   attribute adult : Bool = true
-  attribute email : String
+  attribute email : String?
 
   validates :name, presence: true, length: {minimum: 3, too_short: "must be 3 characters long"}
   validates :age, numericality: {:greater_than => 5}
@@ -61,6 +61,14 @@ class CustomError < ORM
 end
 
 describe ActiveModel::Validation do
+  describe "nilability" do
+    it "validates all non-nillable fields have values" do
+      person = Person.new
+      person.valid?.should be_false
+      person.errors[0].to_s.should eq "name should not be nil"
+    end
+  end
+
   describe "presence" do
     it "validates presence of name" do
       person = Person.new(name: "John Doe")
@@ -68,20 +76,13 @@ describe ActiveModel::Validation do
     end
 
     it "returns false if name is not present" do
-      person = Person.new
+      person = Person.new(name: "")
       person.valid?.should eq false
       person.errors[0].to_s.should eq "name is required"
 
       person = Person.new(name: "")
       person.valid?.should eq false
       person.errors[0].to_s.should eq "name is required"
-    end
-
-    it "returns false if age is not present" do
-      person = Person.new name: "bob"
-      person.age = nil
-      person.valid?.should eq false
-      person.errors[0].to_s.should eq "age must be greater than 5"
     end
   end
 

--- a/src/active-model/http-params.cr
+++ b/src/active-model/http-params.cr
@@ -1,0 +1,8 @@
+struct Time
+  # Parse `Time` from an HTTP param as unix timestamp.
+  def self.from_http_param(value : String) : Time
+    Time.unix(value.to_i64)
+  rescue ArgumentError
+    raise TypeCastError.new
+  end
+end

--- a/src/active-model/model.cr
+++ b/src/active-model/model.cr
@@ -388,7 +388,7 @@ abstract class ActiveModel::Model
         data = JSON.parse(json)
         {% for name, opts in FIELDS %}
           {% if opts[:mass_assign] %}
-            self.{{name}} = model.{{name}} if data[{{name.stringify}}]?
+            self.{{name}} = model.{{name}} if data[{{name.stringify}}]? && self.{{name}} != model.{{name}}
           {% end %}
         {% end %}
 
@@ -400,7 +400,7 @@ abstract class ActiveModel::Model
         model = self.class.from_trusted_json(json)
         data = JSON.parse(json)
         {% for name, opts in FIELDS %}
-          self.{{name}} = model.{{name}} if data[{{name.stringify}}]?
+          self.{{name}} = model.{{name}} if data[{{name.stringify}}]? && self.{{name}} != model.{{name}}
         {% end %}
 
         self
@@ -413,7 +413,7 @@ abstract class ActiveModel::Model
         data = YAML.parse(yaml)
         {% for name, opts in FIELDS %}
           {% if opts[:mass_assign] %}
-            self.{{name}} = model.{{name}} if data[{{name.stringify}}]?
+            self.{{name}} = model.{{name}} if data[{{name.stringify}}]? && self.{{name}} != model.{{name}}
           {% end %}
         {% end %}
 
@@ -425,7 +425,7 @@ abstract class ActiveModel::Model
         model = self.class.from_trusted_yaml(yaml)
         data = YAML.parse(yaml)
         {% for name, opts in FIELDS %}
-          self.{{name}} = model.{{name}} if data[{{name.stringify}}]?
+          self.{{name}} = model.{{name}} if data[{{name.stringify}}]? && self.{{name}} != model.{{name}}
         {% end %}
 
         self

--- a/src/active-model/model.cr
+++ b/src/active-model/model.cr
@@ -11,6 +11,10 @@ abstract class ActiveModel::Model
   # :nodoc:
   FIELD_MAPPINGS = {} of Nil => Nil
 
+  module Missing
+    extend self
+  end
+
   macro inherited
     # Macro level constants
 
@@ -135,6 +139,18 @@ abstract class ActiveModel::Model
           :{{name}} => @{{name}},
         {% end %}
       } {% if PERSIST.empty? %} of Nil => Nil {% end %}
+    end
+
+    def assign_attributes(
+      {% for name, opts in FIELDS %}
+        {{name.id}} : {{opts[:klass]}} | Missing = Missing,
+      {% end %}
+    )
+      {% for name, opts in FIELDS %}
+        {% if opts[:mass_assign] == true %}
+          self.{{name.id}} = {{name.id}} unless {{name.id}}.is_a?(Missing)
+        {% end %}
+      {% end %}
     end
 
     # Accept HTTP params

--- a/src/active-model/model.cr
+++ b/src/active-model/model.cr
@@ -134,20 +134,6 @@ abstract class ActiveModel::Model
       } {% if PERSIST.empty? %} of Nil => Nil {% end %}
     end
 
-    def assign_attributes(
-      {% for name, opts in FIELDS %}
-        {{name}} : {{opts[:klass]}} {% unless opts[:klass].nilable? %} | Nil {% end %} = nil,
-      {% end %}
-    )
-      {% for name, opts in FIELDS %}
-        {% if opts[:mass_assign] %}
-          self.{{name}} = {{name}} unless {{ name }}.nil?
-        {% end %}
-      {% end %}
-
-      self
-    end
-
     # Accept HTTP params
     def assign_attributes(params : HTTP::Params | Hash(String, String) | Tuple(String, String))
       __from_object_params__(params)

--- a/src/active-model/model.cr
+++ b/src/active-model/model.cr
@@ -3,6 +3,9 @@ require "json"
 require "json_mapping"
 require "yaml"
 require "yaml_mapping"
+require "http-params-serializable/ext"
+
+require "./http-params"
 
 abstract class ActiveModel::Model
   # :nodoc:
@@ -147,37 +150,9 @@ abstract class ActiveModel::Model
     {% for name, opts in FIELDS %}
       {% if opts[:mass_assign] %}
         value = {{ params.id }}[{{name.stringify}}]?
+
         if value
-          {% coerce = opts[:klass].stringify %}
-          {% if coerce == "String" %}
-            self.{{name}} = value
-          {% elsif coerce == "Int8" %}
-            self.{{name}} = value.to_i8
-          {% elsif coerce == "Int16" %}
-            self.{{name}} = value.to_i16
-          {% elsif coerce == "Int32" %}
-            self.{{name}} = value.to_i32
-          {% elsif coerce == "Int64" %}
-            self.{{name}} = value.to_i64
-          {% elsif coerce == "UInt8" %}
-            self.{{name}} = value.to_u8
-          {% elsif coerce == "UInt16" %}
-            self.{{name}} = value.to_u16
-          {% elsif coerce == "UInt32" %}
-            self.{{name}} = value.to_u32
-          {% elsif coerce == "UInt64" %}
-            self.{{name}} = value.to_u64
-          {% elsif coerce == "BigDecimal" %}
-            self.{{name}} = value.to_big_d
-          {% elsif coerce == "BigInt" %}
-            self.{{name}} = value.to_big_i
-          {% elsif coerce == "Float32" %}
-            self.{{name}} = value.to_f32
-          {% elsif coerce == "Float64" %}
-            self.{{name}} = value.to_f64
-          {% elsif coerce == "Bool" %}
-            self.{{name}} = value[0].downcase == 't'
-          {% end %}
+          self.{{name}} = {{ opts[:klass] }}.from_http_param(value)
         end
       {% end %}
     {% end %}


### PR DESCRIPTION
A `Model`'s getter/setters now return/accept the type defined in `attribute`.
The underlying type is always nilable however if a non-nil field is accessed and the underlying value is nil, a `NilAssertionError` is raised.

Fixes #18, fixes #17