### PR TITLE
fix(model): check for key presence in #apply_from_(json|yaml)

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: active-model
-version: 2.0.1
+version: 2.0.2
 
 dependencies:
   http-params-serializable:

--- a/src/active-model/model.cr
+++ b/src/active-model/model.cr
@@ -376,10 +376,10 @@ abstract class ActiveModel::Model
       def assign_attributes_from_json(json)
         json = json.read_string(json.read_remaining) if json.responds_to? :read_remaining && json.responds_to? :read_string
         model = self.class.from_json(json)
-        data = JSON.parse(json)
+        data = JSON.parse(json).as_h
         {% for name, opts in FIELDS %}
           {% if opts[:mass_assign] %}
-            self.{{name}} = model.{{name}} if data[{{name.stringify}}]? && self.{{name}} != model.{{name}}
+            self.{{name}} = model.{{name}} if data.has_key?({{name.stringify}}) && self.{{name}} != model.{{name}}
           {% end %}
         {% end %}
 
@@ -389,9 +389,9 @@ abstract class ActiveModel::Model
       def assign_attributes_from_trusted_json(json)
         json = json.read_string(json.read_remaining) if json.responds_to? :read_remaining && json.responds_to? :read_string
         model = self.class.from_trusted_json(json)
-        data = JSON.parse(json)
+        data = JSON.parse(json).as_h
         {% for name, opts in FIELDS %}
-          self.{{name}} = model.{{name}} if data[{{name.stringify}}]? && self.{{name}} != model.{{name}}
+          self.{{name}} = model.{{name}} if data.has_key?({{name.stringify}}) && self.{{name}} != model.{{name}}
         {% end %}
 
         self
@@ -401,10 +401,10 @@ abstract class ActiveModel::Model
       def assign_attributes_from_yaml(yaml)
         yaml = yaml.read_string(yaml.read_remaining) if yaml.responds_to? :read_remaining && yaml.responds_to? :read_string
         model = self.class.from_yaml(yaml)
-        data = YAML.parse(yaml)
+        data = YAML.parse(yaml).as_h
         {% for name, opts in FIELDS %}
           {% if opts[:mass_assign] %}
-            self.{{name}} = model.{{name}} if data[{{name.stringify}}]? && self.{{name}} != model.{{name}}
+            self.{{name}} = model.{{name}} if data.has_key?({{name.stringify}}) && self.{{name}} != model.{{name}}
           {% end %}
         {% end %}
 
@@ -414,9 +414,9 @@ abstract class ActiveModel::Model
       def assign_attributes_from_trusted_yaml(yaml)
         yaml = yaml.read_string(yaml.read_remaining) if yaml.responds_to? :read_remaining && yaml.responds_to? :read_string
         model = self.class.from_trusted_yaml(yaml)
-        data = YAML.parse(yaml)
+        data = YAML.parse(yaml).as_h
         {% for name, opts in FIELDS %}
-          self.{{name}} = model.{{name}} if data[{{name.stringify}}]? && self.{{name}} != model.{{name}}
+          self.{{name}} = model.{{name}} if data.has_key?({{name.stringify}}) && self.{{name}} != model.{{name}}
         {% end %}
 
         self


### PR DESCRIPTION
Check for key presence rather than truthiness when performing `Model#assign_from_(yaml|json)` and `Model#assign_from_trusted_(yaml|json)`