### PR TITLE
build(shard.yml): use patch branch of http-params-serializable

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,10 +1,10 @@
 name: active-model
-version: 2.0.2
+version: 2.0.3
 
 dependencies:
   http-params-serializable:
-    github: vladfaust/http-params-serializable
-    version: ~> 0.3
+    github: caspiano/http-params-serializable
+    branch: chore/0.36.0
   json_mapping:
     github: crystal-lang/json_mapping.cr
   yaml_mapping:


### PR DESCRIPTION
Update to use a patched version of [http-params-serializable](https://github.com/vladfaust/http-params-serializable)