### PR TITLE
revert(model): fix enum serialisation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: crystal
-install:
-  - shards install
-script:
-  - crystal spec
-  - bin/ameba

--- a/README.md
+++ b/README.md
@@ -31,10 +31,8 @@ p.attributes # => {:name => "Bob Jane", :age => 32}
 
 The `attribute` macro takes two parameters. The field name with type and an optional default value.
 
-#### `enum_attributes`
-
-Allows type safe enum defined attributes.<br>
-Same signature as `attribute` with an optional parameter `column_type` to specify the serialisation of the enum member to either String or Int32, default is Int32.
+You can also define enum attributes!<br>
+The default serialisation for enums is to a downcased string. Use [`Enum::ValueConverter(T)`](https://crystal-lang.org/api/latest/Enum/ValueConverter.html) if you want to serialise to the value backing members of the enum.
 
 ```ruby
 require "active-model"
@@ -45,7 +43,7 @@ class Order < ActiveModel::Model
    Burger
   end
 
-  enum_attribute product : Product = Product::Fries, column_type: String
+  attribute product : Product = Product::Fries
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Spider-Gazelle ActiveModel
 
-[![Build Status](https://travis-ci.org/spider-gazelle/active-model.svg?branch=master)](https://travis-ci.org/spider-gazelle/active-model)
+[![CI](https://github.com/spider-gazelle/active-model/actions/workflows/CI.yml/badge.svg)](https://github.com/spider-gazelle/active-model/actions/workflows/CI.yml)
+[![Crystal Version](https://img.shields.io/badge/crystal%20-1.0.0-brightgreen.svg)](https://crystal-lang.org/api/1.0.0/)
 
 Active Model provides a known set of interfaces for usage in model classes. Active Model also helps with building custom ORMs.
 
@@ -34,7 +35,7 @@ The `attribute` macro takes two parameters. The field name with type and an opti
 You can also define enum attributes!<br>
 The default serialisation for enums is to a downcased string. Use [`Enum::ValueConverter(T)`](https://crystal-lang.org/api/latest/Enum/ValueConverter.html) if you want to serialise to the value backing members of the enum.
 
-```ruby
+```crystal
 require "active-model"
 
 class Order < ActiveModel::Model
@@ -43,7 +44,13 @@ class Order < ActiveModel::Model
    Burger
   end
 
+  enum Size
+    Medium
+    ExtraMedium
+  end
+
   attribute product : Product = Product::Fries
+  attribute size : Size = Size::ExtraMedium, converter: Enum::ValueConverter(Size)
 end
 ```
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: active-model
-version: 2.0.4
+version: 2.0.5
 crystal: ">= 1.0.0"
 
 dependencies:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: active-model
-version: 2.0.5
+version: 3.0.0
 crystal: ">= 1.0.0"
 
 dependencies:

--- a/spec/model_spec.cr
+++ b/spec/model_spec.cr
@@ -55,8 +55,8 @@ class EnumAttributes < ActiveModel::Model
     Fries
   end
 
-  enum_attribute size : Size, column_type: Int32, custom_tag: "what what"
-  enum_attribute product : Product = Product::Fries, column_type: String
+  attribute size : Size, converter: Enum::ValueConverter(Size), custom_tag: "what what"
+  attribute product : Product = Product::Fries
 end
 
 class Changes < BaseKlass
@@ -218,7 +218,7 @@ describe ActiveModel::Model do
     end
   end
 
-  describe "enum_attributes" do
+  describe "enum attributes" do
     it "should allow enums as attributes" do
       model = EnumAttributes.new(size: EnumAttributes::Size::Medium)
       model.size.should eq EnumAttributes::Size::Medium
@@ -241,7 +241,7 @@ describe ActiveModel::Model do
       yaml = YAML.parse(model.to_yaml)
 
       yaml["size"].should eq EnumAttributes::Size::Medium.to_i
-      json["product"].should eq EnumAttributes::Product::Fries.to_s
+      json["product"].should eq EnumAttributes::Product::Fries.to_s.downcase
     end
 
     it "tracks changes to enum attributes" do

--- a/src/active-model/model.cr
+++ b/src/active-model/model.cr
@@ -472,11 +472,7 @@ abstract class ActiveModel::Model
 
     class {{ converter }}
       def self.from_json(value : JSON::PullParser) : {{enum_type}}
-        {% if column_type_str == "Int32" %}
-          {{enum_type}}.from_value(value.read_int)
-        {% else %}
-          {{enum_type}}.new(value)
-        {% end %}
+        {{enum_type}}.new(value)
       end
 
       def self.to_json(value : {{enum_type}}, json : JSON::Builder)

--- a/src/active-model/validation.cr
+++ b/src/active-model/validation.cr
@@ -139,7 +139,7 @@ module ActiveModel::Validation
 
     {% if confirmation %}
       {% for field, index in fields %}
-        {% type = @type.instance_vars.select { |ivar| ivar.name == field.id }.map(&.type)[0] %}
+        {% type = @type.instance_vars.select(&.name.==(field.id)).map(&.type)[0] %}
 
         # Using attribute for named params support
         attribute {{field.id}}_confirmation : {{FIELDS[field.id][:klass]}}, persistence: false


### PR DESCRIPTION
Removes `enum_attribute` for serialisation entirely.
Please use [`Enum::ValueConverter(T)`](https://crystal-lang.org/api/latest/Enum/ValueConverter.html) to achieve the same effect.
