### PR TITLE
feat: serialization groups

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,8 +1,6 @@
 name: CI
 on:
   push:
-  pull_request:
-  workflow_dispatch:
   schedule:
     - cron: "0 6 * * 1"
 jobs:
@@ -20,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
-      run: shards install --ignore-crystal-version
+      run: shards install
     - name: Lint
       run: ./bin/ameba
     - name: Format

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ end
 The `serialization_group` argument to `attribute` accepts an `Array(Symbol)` or `Symbol`.
 This will include the attribute in a generated serializer, `#to_<group>_json`.
 
-The `define_to_json` macro allows for defining subset serializations via `only` and `except` arguments.
+The `define_to_json` macro allows for defining subset serializations via `only` and `except` arguments. The `methods` argument allows for inclusion of instance methods in the serializer.
 
 ```crystal
 require "active-model"
@@ -147,6 +147,9 @@ class SerializationGroups < ActiveModel::Model
 
   define_to_json :some, only: [:joined, :another]
   define_to_json :most, except: :everywhere
+  define_to_json :method, only: :joined, methods: :foo
+
+  getter foo = "foo"
 end
 
 m = SerializationGroups.new
@@ -155,4 +158,5 @@ m.to_admin_json  # {"everywhere":"hi","joined":0}
 m.to_user_json   # {"everywhere":"hi","joined":0,"mates":1}
 m.to_some_json   # {"joined":0,"another":"ok"}
 m.to_most_json   # {"joined":0,"mates":0,"another":"ok"}
+m.to_method_json # {"joined":0,"foo":"foo"}
 ```

--- a/README.md
+++ b/README.md
@@ -128,3 +128,31 @@ class Person < ActiveModel::Model
   end
 end
 ```
+
+#### Serialization
+
+The `serialization_group` argument to `attribute` accepts an `Array(Symbol)` or `Symbol`.
+This will include the attribute in a generated serializer, `#to_<group>_json`.
+
+The `define_to_json` macro allows for defining subset serializations via `only` and `except` arguments.
+
+```crystal
+require "active-model"
+
+class SerializationGroups < ActiveModel::Model
+  attribute everywhere : String = "hi", serialization_group: [:admin, :user, :public]
+  attribute joined : Int64 = 0, serialization_group: [:admin, :user]
+  attribute mates : Int64 = 0, serialization_group: :user
+  attribute another : String = "ok"
+
+  define_to_json :some, only: [:joined, :another]
+  define_to_json :most, except: :everywhere
+end
+
+m = SerializationGroups.new
+m.to_public_json # {"everywhere":"hi"}
+m.to_admin_json  # {"everywhere":"hi","joined":0}
+m.to_user_json   # {"everywhere":"hi","joined":0,"mates":1}
+m.to_some_json   # {"joined":0,"another":"ok"}
+m.to_most_json   # {"joined":0,"mates":0,"another":"ok"}
+```

--- a/shard.yml
+++ b/shard.yml
@@ -1,11 +1,11 @@
 name: active-model
-version: 3.0.0
+version: 3.1.0
 crystal: ">= 1.0.0"
 
 dependencies:
   http-params-serializable:
-    github: caspiano/http-params-serializable
-    branch: chore/0.36.0
+    github: place-labs/http-params-serializable
+    version: ~> 0.5
   json_mapping:
     github: crystal-lang/json_mapping.cr
   yaml_mapping:

--- a/spec/model_spec.cr
+++ b/spec/model_spec.cr
@@ -34,6 +34,9 @@ class SerializationGroups < BaseKlass
   attribute everywhere : String = "hi", serialization_groups: [:admin, :user, :public]
   attribute joined : Int64 = 0, serialization_groups: [:admin, :user]
   attribute mates : Int64 = 0, serialization_groups: [:user]
+
+  subset_json :some, only: [:joined]
+  subset_json :most, except: [:everywhere]
 end
 
 class Inheritance < BaseKlass
@@ -346,14 +349,23 @@ describe ActiveModel::Model do
       i.no_default = "test"
       i.to_json.should eq "{\"boolean\":true,\"string\":\"hello\",\"integer\":45,\"no_default\":\"test\"}"
     end
-  end
 
-  describe "`serialization_groups` option" do
-    it "generates serializers" do
-      m = SerializationGroups.new
+    m = SerializationGroups.new
+
+    it "`serialization_groups` optio ngenerates serializers" do
       m.to_admin_json.should eq ({everywhere: m.everywhere, joined: m.joined}).to_json
       m.to_user_json.should eq ({everywhere: m.everywhere, joined: m.joined, mates: m.mates}).to_json
       m.to_public_json.should eq ({everywhere: m.everywhere}).to_json
+    end
+
+    describe "subset_json" do
+      it "selects for attributes in `only`" do
+        m.to_some_json.should eq ({joined: m.joined}).to_json
+      end
+
+      it "rejects attributes in `except`" do
+        m.to_most_json.should eq ({joined: m.joined, mates: m.mates}).to_json
+      end
     end
   end
 

--- a/spec/model_spec.cr
+++ b/spec/model_spec.cr
@@ -36,8 +36,8 @@ class SerializationGroups < BaseKlass
   attribute mates : Int64 = 0, serialization_group: :user
   attribute another : String = "ok"
 
-  subset_json :some, only: [:joined, :another]
-  subset_json :most, except: :everywhere
+  define_to_json :some, only: [:joined, :another]
+  define_to_json :most, except: :everywhere
 end
 
 class Inheritance < BaseKlass
@@ -359,7 +359,7 @@ describe ActiveModel::Model do
       m.to_public_json.should eq ({everywhere: m.everywhere}).to_json
     end
 
-    describe "subset_json" do
+    describe "define_to_json" do
       it "selects for attributes in `only`" do
         m.to_some_json.should eq ({joined: m.joined, another: m.another}).to_json
       end

--- a/spec/model_spec.cr
+++ b/spec/model_spec.cr
@@ -31,12 +31,13 @@ class SetterBlock < BaseKlass
 end
 
 class SerializationGroups < BaseKlass
-  attribute everywhere : String = "hi", serialization_groups: [:admin, :user, :public]
-  attribute joined : Int64 = 0, serialization_groups: [:admin, :user]
-  attribute mates : Int64 = 0, serialization_groups: [:user]
+  attribute everywhere : String = "hi", serialization_group: [:admin, :user, :public]
+  attribute joined : Int64 = 0, serialization_group: [:admin, :user]
+  attribute mates : Int64 = 0, serialization_group: :user
+  attribute another : String = "ok"
 
-  subset_json :some, only: [:joined]
-  subset_json :most, except: [:everywhere]
+  subset_json :some, only: [:joined, :another]
+  subset_json :most, except: :everywhere
 end
 
 class Inheritance < BaseKlass
@@ -352,7 +353,7 @@ describe ActiveModel::Model do
 
     m = SerializationGroups.new
 
-    it "`serialization_groups` optio ngenerates serializers" do
+    it "`serialization_group` optio ngenerates serializers" do
       m.to_admin_json.should eq ({everywhere: m.everywhere, joined: m.joined}).to_json
       m.to_user_json.should eq ({everywhere: m.everywhere, joined: m.joined, mates: m.mates}).to_json
       m.to_public_json.should eq ({everywhere: m.everywhere}).to_json
@@ -360,11 +361,11 @@ describe ActiveModel::Model do
 
     describe "subset_json" do
       it "selects for attributes in `only`" do
-        m.to_some_json.should eq ({joined: m.joined}).to_json
+        m.to_some_json.should eq ({joined: m.joined, another: m.another}).to_json
       end
 
       it "rejects attributes in `except`" do
-        m.to_most_json.should eq ({joined: m.joined, mates: m.mates}).to_json
+        m.to_most_json.should eq ({joined: m.joined, mates: m.mates, another: m.another}).to_json
       end
     end
   end

--- a/spec/model_spec.cr
+++ b/spec/model_spec.cr
@@ -30,6 +30,12 @@ class SetterBlock < BaseKlass
   end
 end
 
+class SerializationGroups < BaseKlass
+  attribute everywhere : String = "hi", serialization_groups: [:admin, :user, :public]
+  attribute joined : Int64 = 0, serialization_groups: [:admin, :user]
+  attribute mates : Int64 = 0, serialization_groups: [:user]
+end
+
 class Inheritance < BaseKlass
   attribute boolean : Bool = true
 
@@ -333,12 +339,21 @@ describe ActiveModel::Model do
   end
 
   describe "serialization" do
-    it "should support to_json" do
+    it "#to_json" do
       i = Inheritance.new
       i.to_json.should eq "{\"boolean\":true,\"string\":\"hello\",\"integer\":45}"
 
       i.no_default = "test"
       i.to_json.should eq "{\"boolean\":true,\"string\":\"hello\",\"integer\":45,\"no_default\":\"test\"}"
+    end
+  end
+
+  describe "`serialization_groups` option" do
+    it "generates serializers" do
+      m = SerializationGroups.new
+      m.to_admin_json.should eq ({everywhere: m.everywhere, joined: m.joined}).to_json
+      m.to_user_json.should eq ({everywhere: m.everywhere, joined: m.joined, mates: m.mates}).to_json
+      m.to_public_json.should eq ({everywhere: m.everywhere}).to_json
     end
   end
 

--- a/spec/model_spec.cr
+++ b/spec/model_spec.cr
@@ -38,6 +38,9 @@ class SerializationGroups < BaseKlass
 
   define_to_json :some, only: [:joined, :another]
   define_to_json :most, except: :everywhere
+  define_to_json :with_method, only: :joined, methods: :foo
+
+  getter foo = "foo"
 end
 
 class Inheritance < BaseKlass
@@ -366,6 +369,10 @@ describe ActiveModel::Model do
 
       it "rejects attributes in `except`" do
         m.to_most_json.should eq ({joined: m.joined, mates: m.mates, another: m.another}).to_json
+      end
+
+      it "includes methods via `methods`" do
+        m.to_with_method_json.should eq ({joined: m.joined, foo: m.foo}).to_json
       end
     end
   end

--- a/src/active-model/http-params.cr
+++ b/src/active-model/http-params.cr
@@ -1,8 +1,10 @@
+# :nodoc:
 struct Time
+  # :nodoc:
   # Parse `Time` from an HTTP param as unix timestamp.
   def self.from_http_param(value : String) : Time
     Time.unix(value.to_i64)
   rescue ArgumentError
-    raise TypeCastError.new
+    raise TypeCastError.new("Failed to cast #{value} to unix epoch")
   end
 end

--- a/src/active-model/model.cr
+++ b/src/active-model/model.cr
@@ -129,9 +129,12 @@ abstract class ActiveModel::Model
       def to_{{ serialization_group.id }}_json(json : ::JSON::Builder)
         json.object do
           # Serialize attributes
-          {% for kv in FIELDS.to_a.select do |(_n, o)|
-                         o[:serialization_group] && o[:serialization_group].includes?(serialization_group)
-                       end %}
+          {%
+            in_group = FIELDS.to_a.select do |(_n, o)|
+              o[:serialization_group] && o[:serialization_group].includes?(serialization_group)
+            end
+          %}
+          {% for kv in in_group %}
             {% name = kv[0] %}
             {% opts = kv[1] %}
             %value = @{{name}}

--- a/src/active-model/model.cr
+++ b/src/active-model/model.cr
@@ -57,7 +57,7 @@ abstract class ActiveModel::Model
 
   protected def validation_error; end
 
-  macro subset_json(group, except = [] of Symbol, only = [] of Symbol)
+  macro define_to_json(group, except = [] of Symbol, only = [] of Symbol)
     {% only = [only] if only.is_a?(SymbolLiteral) %}
     {% except = [except] if except.is_a?(SymbolLiteral) %}
     {% raise "expected `except` to be an Array(Symbol) | Symbol, got #{except.class_name}" unless except.is_a? ArrayLiteral && except.all? &.is_a?(SymbolLiteral) %}


### PR DESCRIPTION
Add the `serialization_groups` option to an attribute's tags.
This allows a user to specify sets of attributes that will have custom serializers.

In addition to `#to_x_json : String`, `#to_x_json(io : IO) : Nil` is defined.

```crystal
require "active-model"

class SerializationGroups < ActiveModel::Model
  attribute everywhere : String = "hi", serialization_groups: [:admin, :user, :public]
  attribute joined : Int64 = 0, serialization_groups: [:admin, :user]
  attribute mates : Int64 = 0, serialization_groups: [:user]
end

m = SerializationGroups.new
m.to_public_json # {"everywhere":"hi"}
m.to_admin_json  # {"everywhere":"hi","joined":0}
m.to_user_json   # {"everywhere":"hi","joined":0,"mates":1}
```