### PR TITLE
feat: add support for including fields in json serde when persistence…

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: active-model
-version: 4.3.0
+version: 4.3.1
 crystal: ">= 1.0.0"
 license: MIT
 


### PR DESCRIPTION
This PR adds a new `param` to `attribute` macro, that works in relation with `persistence` flag. Current `persistence` flag turned on/off `JSON::Field` ignore flag. But with this addition, setting `show` as `true` and `persistence` as `false`, will mark the field as non persistent (for ORM) but will have this field displayed in `to_json`.

Another change this PR deal with is, making  `serialization_group` to respect the `json_key`.